### PR TITLE
Determine storage type from endpoint

### DIFF
--- a/roles/tpa_single_node/meta/argument_specs.yml
+++ b/roles/tpa_single_node/meta/argument_specs.yml
@@ -140,7 +140,7 @@ argument_specs:
         type: "str"
         required: false
         version_added: "2.0.0"
-      tpa_single_node_storage_endpoint:
+      tpa_single_node_storage_minio_endpoint:
         description: "Read from 'TPA_STORAGE_MINIO_ENDPOINT' env var"
         type: "str"
         required: false

--- a/roles/tpa_single_node/meta/argument_specs.yml
+++ b/roles/tpa_single_node/meta/argument_specs.yml
@@ -120,11 +120,6 @@ argument_specs:
         type: "str"
         required: false
         version_added: "2.0.0"
-      tpa_single_node_storage_type:
-        description: "Read from 'TPA_STORAGE_TYPE' env var"
-        type: "str"
-        required: true
-        version_added: "2.0.0"
       tpa_single_node_storage_access_key:
         description: "Read from 'TPA_STORAGE_ACCESS_KEY' env var"
         type: "str"

--- a/roles/tpa_single_node/templates/manifests/server/Deployment.yaml.j2
+++ b/roles/tpa_single_node/templates/manifests/server/Deployment.yaml.j2
@@ -76,7 +76,7 @@ spec:
               value: "{{ tpa_single_node_pg_user_passwd }}"
             - name: TRUSTD_DB_SSLMODE
               value: allow
-{% if tpa_single_node_storage_type == 'fs' %}
+{% if tpa_single_node_storage_region == 'None' %}
             - name: TRUSTD_STORAGE_STRATEGY
               value: fs
             - name: TRUSTD_STORAGE_FS_PATH
@@ -142,7 +142,7 @@ spec:
               subPath: auth.yaml
             - name: oidc-secret
               mountPath: /etc/oidcsecret
-{% if tpa_single_node_storage_type == 'fs' %}
+{% if tpa_single_node_storage_endpoint == 'None' %}
             - name: storage
               mountPath: /data/storage
 {% else %}
@@ -159,7 +159,7 @@ spec:
         - name: oidc-secret
           secret:
             secretName: oidc_secret
-{% if tpa_single_node_storage_type == 'fs' %}
+{% if tpa_single_node_storage_endpoint == 'None' %}
         - name: storage
           persistentVolumeClaim:
             claimName: storage

--- a/roles/tpa_single_node/templates/manifests/server/Deployment.yaml.j2
+++ b/roles/tpa_single_node/templates/manifests/server/Deployment.yaml.j2
@@ -103,7 +103,6 @@ spec:
               value: "{{ tpa_single_node_storage_endpoint }}"
 {% endif %}
 {% endif %}
-
             - name: SWAGGER_UI_OIDC_ISSUER_URL
               value: "{{ tpa_single_node_oidc_issuer_url }}"
             - name: SWAGGER_UI_OIDC_CLIENT_ID

--- a/roles/tpa_single_node/templates/manifests/server/Deployment.yaml.j2
+++ b/roles/tpa_single_node/templates/manifests/server/Deployment.yaml.j2
@@ -98,9 +98,9 @@ spec:
               value: "{{ tpa_single_node_storage_bucket }}"
             - name: TRUSTD_S3_REGION
               value: "{{ tpa_single_node_storage_region }}"
-{% if tpa_single_node_storage_endpoint != "None" %}
+{% if tpa_single_node_storage_minio_endpoint != "None" %}
             - name: STORAGE_ENDPOINT
-              value: "{{ tpa_single_node_storage_endpoint }}"
+              value: "{{ tpa_single_node_storage_minio_endpoint }}"
 {% endif %}
 {% endif %}
             - name: SWAGGER_UI_OIDC_ISSUER_URL
@@ -141,7 +141,7 @@ spec:
               subPath: auth.yaml
             - name: oidc-secret
               mountPath: /etc/oidcsecret
-{% if tpa_single_node_storage_endpoint == 'None' %}
+{% if tpa_single_node_storage_region == 'None' %}
             - name: storage
               mountPath: /data/storage
 {% else %}
@@ -158,7 +158,7 @@ spec:
         - name: oidc-secret
           secret:
             secretName: oidc_secret
-{% if tpa_single_node_storage_endpoint == 'None' %}
+{% if tpa_single_node_storage_region == 'None' %}
         - name: storage
           persistentVolumeClaim:
             claimName: storage

--- a/roles/tpa_single_node/vars/main.yml
+++ b/roles/tpa_single_node/vars/main.yml
@@ -36,7 +36,7 @@ tpa_single_node_storage_access_key: "{{ lookup('env', 'TPA_STORAGE_ACCESS_KEY') 
 tpa_single_node_storage_secret_key: "{{ lookup('env', 'TPA_STORAGE_SECRET_KEY') | default('None', true) }}" # S3/minio root password
 tpa_single_node_storage_bucket: "{{ lookup('env', 'TPA_STORAGE_BUCKET') | default('None', true) }}" # S3/minio bucket
 tpa_single_node_storage_region: "{{ lookup('env', 'TPA_STORAGE_REGION') | default('None', true) }}" # S3/minio region
-tpa_single_node_storage_endpoint: "{{ lookup('env', 'TPA_STORAGE_MINIO_ENDPOINT') | default('None', true) }}" # Minio endpoint
+tpa_single_node_storage_minio_endpoint: "{{ lookup('env', 'TPA_STORAGE_MINIO_ENDPOINT') | default('None', true) }}" # Minio endpoint
 
 # TSL CA Certificates
 tpa_single_node_root_ca: "{{ tpa_single_node_certificates_dir }}/rootCA.crt"

--- a/roles/tpa_single_node/vars/main.yml
+++ b/roles/tpa_single_node/vars/main.yml
@@ -32,11 +32,10 @@ tpa_single_node_oidc_client_secret: "{{ lookup('env', 'TPA_OIDC_CLIENT_SECRET') 
 tpa_single_node_aws_cognito_domain: "{{ lookup('env', 'TPA_OIDC_COGNITO_DOMAIN') | default('None', true) }}"
 
 # Storage Service
-tpa_single_node_storage_type: "{{ lookup('env', 'TPA_STORAGE_TYPE') | default('fs', true) }}"
-tpa_single_node_storage_access_key: "{{ lookup('env', 'TPA_STORAGE_ACCESS_KEY') | default('None', true) }}"  # S3/minio root username
+tpa_single_node_storage_access_key: "{{ lookup('env', 'TPA_STORAGE_ACCESS_KEY') | default('None', true) }}" # S3/minio root username
 tpa_single_node_storage_secret_key: "{{ lookup('env', 'TPA_STORAGE_SECRET_KEY') | default('None', true) }}" # S3/minio root password
 tpa_single_node_storage_bucket: "{{ lookup('env', 'TPA_STORAGE_S3_BUCKET') | default('None', true) }}" # S3/minio bucket
-tpa_single_node_storage_region: "{{ lookup('env', 'TPA_STORAGE_REGION') | default('eu-west-1', true) }}" # S3/minio region
+tpa_single_node_storage_region: "{{ lookup('env', 'TPA_STORAGE_REGION') | default('None', true) }}" # S3/minio region
 tpa_single_node_storage_endpoint: "{{ lookup('env', 'TPA_STORAGE_MINIO_ENDPOINT') | default('None', true) }}" # Minio endpoint
 
 # TSL CA Certificates

--- a/roles/tpa_single_node/vars/main.yml
+++ b/roles/tpa_single_node/vars/main.yml
@@ -34,7 +34,7 @@ tpa_single_node_aws_cognito_domain: "{{ lookup('env', 'TPA_OIDC_COGNITO_DOMAIN')
 # Storage Service
 tpa_single_node_storage_access_key: "{{ lookup('env', 'TPA_STORAGE_ACCESS_KEY') | default('None', true) }}" # S3/minio root username
 tpa_single_node_storage_secret_key: "{{ lookup('env', 'TPA_STORAGE_SECRET_KEY') | default('None', true) }}" # S3/minio root password
-tpa_single_node_storage_bucket: "{{ lookup('env', 'TPA_STORAGE_S3_BUCKET') | default('None', true) }}" # S3/minio bucket
+tpa_single_node_storage_bucket: "{{ lookup('env', 'TPA_STORAGE_BUCKET') | default('None', true) }}" # S3/minio bucket
 tpa_single_node_storage_region: "{{ lookup('env', 'TPA_STORAGE_REGION') | default('None', true) }}" # S3/minio region
 tpa_single_node_storage_endpoint: "{{ lookup('env', 'TPA_STORAGE_MINIO_ENDPOINT') | default('None', true) }}" # Minio endpoint
 


### PR DESCRIPTION
`TPA_STORAGE_TYPE` is not needed anymore.

Also note : `TPA_STORAGE_BUCKET` replaces `TPA_STORAGE_S3_BUCKET`
