### PR TITLE
Adding placeholders for OTEL collector

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,16 @@ You can have four importer instances with a single job for each instance by sett
 tpa_single_node_importer: multiple
 ```
 
+Tracing and monitoring of TPA can be enabled using the OTEL Collector. To activate metrics and tracing, set the following environment variables:
+```
+export TPA_OTEL_METRICS_ENABLED=true
+export TPA_OTEL_TRACING_ENABLED=true
+```
+In addition, configure the OTEL Collector endpoint by setting
+```
+export TPA_OTEL_COLLECTOR_ENDPOINT=<OTEL Collector endpoint>
+```
+
 ### Updating the inventory and the playbook
 
 To deploy RHTPA on a Red Hat Enterprise Linux version 9.3 or later do the following:

--- a/roles/tpa_single_node/README.md
+++ b/roles/tpa_single_node/README.md
@@ -61,6 +61,9 @@ Requires RHEL 9.3 or later.
 | tpa_single_node_server_json_limit           | HTTP Server JSON limit                                                 | str  |                                                                                                        |
 | tpa_single_node_upload_limit                | Upload limit for Files                                                 | str  |                                                                                                        |
 | tpa_single_node_storage_compression         | Compression logic for storage                                          | str  |                                                                                                        |
+| tpa_single_node_otel_metrics_enabled        | Enable OTEL metrics                                                    |  str |  `false`                                                                                               |
+| tpa_single_node_otel_tracing_enabled        | Enable OTEL tracing                                                    |  str |  `false`                                                                                               |
+| tpa_single_node_otel_collector_endpoint     | OTEL collector endpoint                                                |  str |  `None`                                                                                                |
 
 ## Example Playbook
 

--- a/roles/tpa_single_node/templates/manifests/importer/Deployment.yaml.j2
+++ b/roles/tpa_single_node/templates/manifests/importer/Deployment.yaml.j2
@@ -111,6 +111,24 @@ spec:
               value: "{{ s3_trust_anchors_list }}"
 {% endif %}
 {% endif %}
+{% if tpa_single_node_otel_collector_endpoint != 'None' %}
+            - name: OTEL_TRACES_SAMPLER
+              value: parentbased_traceidratio
+            - name: OTEL_TRACES_SAMPLER_ARG
+              value: '0.1'
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: "{{ tpa_single_node_otel_collector_endpoint }}"
+            - name: OTEL_BSP_MAX_EXPORT_BATCH_SIZE
+              value: "32"
+{% endif %}
+{% if tpa_single_node_otel_metrics_enabled != 'false' %}
+            - name: METRICS
+              value: "enabled"
+{% endif %}
+{% if tpa_single_node_otel_tracing_enabled != 'false' %}
+            - name: TRACING
+              value: "enabled"
+{% endif %}
           ports:
             - containerPort: 9010
               protocol: TCP

--- a/roles/tpa_single_node/templates/manifests/server/Deployment.yaml.j2
+++ b/roles/tpa_single_node/templates/manifests/server/Deployment.yaml.j2
@@ -147,6 +147,24 @@ spec:
             - name: TRUSTD_DATASET_ENTRY_LIMIT
               value: "{{ tpa_single_node_upload_limit }}"
 {% endif %}
+{% if tpa_single_node_otel_collector_endpoint != 'None' %}
+            - name: OTEL_TRACES_SAMPLER
+              value: parentbased_traceidratio
+            - name: OTEL_TRACES_SAMPLER_ARG
+              value: '0.1'
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: "{{ tpa_single_node_otel_collector_endpoint }}"
+            - name: OTEL_BSP_MAX_EXPORT_BATCH_SIZE
+              value: "32"
+{% endif %}
+{% if tpa_single_node_otel_metrics_enabled != 'false' %}
+            - name: METRICS
+              value: "enabled"
+{% endif %}
+{% if tpa_single_node_otel_tracing_enabled != 'false' %}
+            - name: TRACING
+              value: "enabled"
+{% endif %}
           ports:
             - containerPort: 9010
               protocol: TCP

--- a/roles/tpa_single_node/vars/main.yml
+++ b/roles/tpa_single_node/vars/main.yml
@@ -79,6 +79,11 @@ tpa_single_node_upload_limit: "{{ lookup('env', 'TPA_SERVER_UPLOAD_LIMIT') | def
 # Log Level
 tpa_single_node_log_filter: info
 
+# OTEL collector
+tpa_single_node_otel_collector_endpoint: "{{ lookup('env', 'TPA_OTEL_COLLECTOR_ENDPOINT') | default('None', true) }}"
+tpa_single_node_otel_metrics_enabled: "{{ lookup('env', 'TPA_OTEL_METRICS_ENABLED') | default('false', true) }}"
+tpa_single_node_otel_tracing_enabled: "{{ lookup('env', 'TPA_OTEL_TRACING_ENABLED') | default('false', true) }}"
+
 # defaults file for tpa_single_node
 tpa_single_node_system_packages:
   - podman


### PR DESCRIPTION
To configure and enable metrics and tracing for RHTPA:

- Added a three placeholders for tracing, metrics and otel collector endpoint
- Tested with podman-compose files with the local hosted instance - https://github.com/trustification/trustify/tree/main/etc/telemetry
- Screenshot for reference from prometheus instance:

![image](https://github.com/user-attachments/assets/3eef054d-eaf3-4ab4-8373-fe43026a3786)
