### PR TITLE
feat: add HTTP proxy support for importer container

### DIFF
--- a/roles/tpa_single_node/meta/argument_specs.yml
+++ b/roles/tpa_single_node/meta/argument_specs.yml
@@ -226,3 +226,18 @@ argument_specs:
         description: "Compression logic for storage "
         type: "str"
         version_added: "2.0.0"
+      tpa_single_node_http_proxy:
+        description: "HTTP proxy URL for the importer container. Read from TPA_HTTP_PROXY env var. Sets HTTP_PROXY environment variable."
+        type: "str"
+        required: false
+        version_added: "2.2.6"
+      tpa_single_node_https_proxy:
+        description: "HTTPS proxy URL for the importer container. Read from TPA_HTTPS_PROXY env var. Sets HTTPS_PROXY environment variable."
+        type: "str"
+        required: false
+        version_added: "2.2.6"
+      tpa_single_node_no_proxy:
+        description: "Comma-separated list of hosts to bypass the proxy. Read from TPA_NO_PROXY env var. Sets NO_PROXY environment variable."
+        type: "str"
+        required: false
+        version_added: "2.2.6"

--- a/roles/tpa_single_node/templates/manifests/importer/Deployment.yaml.j2
+++ b/roles/tpa_single_node/templates/manifests/importer/Deployment.yaml.j2
@@ -132,13 +132,19 @@ spec:
 {% if tpa_single_node_http_proxy != 'None' %}
             - name: HTTP_PROXY
               value: "{{ tpa_single_node_http_proxy }}"
+            - name: http_proxy
+              value: "{{ tpa_single_node_http_proxy }}"
 {% endif %}
 {% if tpa_single_node_https_proxy != 'None' %}
             - name: HTTPS_PROXY
               value: "{{ tpa_single_node_https_proxy }}"
+            - name: https_proxy
+              value: "{{ tpa_single_node_https_proxy }}"
 {% endif %}
 {% if tpa_single_node_no_proxy != 'None' %}
             - name: NO_PROXY
+              value: "{{ tpa_single_node_no_proxy }}"
+            - name: no_proxy
               value: "{{ tpa_single_node_no_proxy }}"
 {% endif %}
           ports:

--- a/roles/tpa_single_node/templates/manifests/importer/Deployment.yaml.j2
+++ b/roles/tpa_single_node/templates/manifests/importer/Deployment.yaml.j2
@@ -129,6 +129,18 @@ spec:
             - name: TRACING
               value: "enabled"
 {% endif %}
+{% if tpa_single_node_http_proxy != 'None' %}
+            - name: HTTP_PROXY
+              value: "{{ tpa_single_node_http_proxy }}"
+{% endif %}
+{% if tpa_single_node_https_proxy != 'None' %}
+            - name: HTTPS_PROXY
+              value: "{{ tpa_single_node_https_proxy }}"
+{% endif %}
+{% if tpa_single_node_no_proxy != 'None' %}
+            - name: NO_PROXY
+              value: "{{ tpa_single_node_no_proxy }}"
+{% endif %}
           ports:
             - containerPort: 9010
               protocol: TCP

--- a/roles/tpa_single_node/vars/main.yml
+++ b/roles/tpa_single_node/vars/main.yml
@@ -77,6 +77,11 @@ tpa_single_node_server_req_limit: "{{ lookup('env', 'TPA_SERVER_REQ_LIMIT') | de
 tpa_single_node_server_json_limit: "{{ lookup('env', 'TPA_SERVER_JSON_LIMIT') | default('None', true) }}"
 tpa_single_node_upload_limit: "{{ lookup('env', 'TPA_SERVER_UPLOAD_LIMIT') | default('None', true) }}"
 
+# Proxy
+tpa_single_node_http_proxy: "{{ lookup('env', 'TPA_HTTP_PROXY') | default('None', true) }}"
+tpa_single_node_https_proxy: "{{ lookup('env', 'TPA_HTTPS_PROXY') | default('None', true) }}"
+tpa_single_node_no_proxy: "{{ lookup('env', 'TPA_NO_PROXY') | default('None', true) }}"
+
 # Log Level
 tpa_single_node_log_filter: info
 


### PR DESCRIPTION
Add TPA_HTTP_PROXY, TPA_HTTPS_PROXY, and TPA_NO_PROXY environment variable support so the importer container can route git operations through an HTTP proxy. Required for environments where direct egress to github.com is blocked.