### PR TITLE
fix(migrate-db): add storage configuration to migrate-db template

### DIFF
--- a/roles/tpa_single_node/templates/manifests/init/migrate_database/Deployment.yaml.j2
+++ b/roles/tpa_single_node/templates/manifests/init/migrate_database/Deployment.yaml.j2
@@ -33,7 +33,67 @@ spec:
               value: "{{  tpa_single_node_pg_admin_passwd }}"
             - name: TRUSTD_DB_SSLMODE
               value: {{ tpa_single_node_pg_ssl_mode }}
+{% if tpa_single_node_storage_compression != 'None' %}
+            - name: TRUSTD_STORAGE_COMPRESSION
+              value: {{ tpa_single_node_storage_compression }}
+{% endif %}
+{% if tpa_single_node_storage_region == 'None' %}
+            - name: TRUSTD_STORAGE_STRATEGY
+              value: fs
+            - name: TRUSTD_STORAGE_FS_PATH
+              value: /data/storage
+{% else %}
+            - name: TRUSTD_STORAGE_STRATEGY
+              value: s3
+            - name: TRUSTD_S3_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: storage_secret
+                  key: storage_access_key
+            - name: TRUSTD_S3_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: storage_secret
+                  key: storage_secret_key
+            - name: TRUSTD_S3_BUCKET
+              value: "{{ tpa_single_node_storage_bucket }}"
+            - name: TRUSTD_S3_REGION
+              value: "{{ tpa_single_node_storage_region }}"
+{% if s3_trust_anchors_list is defined %}
+            - name: TRUSTD_S3_TRUST_ANCHORS
+              value: "{{ s3_trust_anchors_list }}"
+{% endif %}
+{% endif %}
           command:
             - trustd
             - db
             - migrate
+          volumeMounts:
+{% if tpa_single_node_storage_region == 'None' %}
+            - name: storage
+              mountPath: /data/storage
+{% else %}
+            - name: storage-secret
+              mountPath: /etc/storagesecret
+              readOnly: true
+{% if s3_trust_anchors_list is defined %}
+            - mountPath: /etc/s3-trust-anchors
+              name: s3-trust-anchors
+              readOnly: true
+{% endif %}
+{% endif %}
+      volumes:
+{% if tpa_single_node_storage_region == 'None' %}
+        - name: storage
+          persistentVolumeClaim:
+            claimName: storage
+{% else %}
+        - name: storage-secret
+          secret:
+            secretName: storage_secret
+{% if s3_trust_anchors_list is defined %}
+        - name: s3-trust-anchors
+          configMap:
+            name: s3-trust-anchors
+{% endif %}
+{% endif %}


### PR DESCRIPTION
The migrate-db Deployment template was missing TRUSTD_STORAGE_STRATEGY env var and volume mounts, causing "Permission denied" errors when the trustd db migrate command attempted to create a local storage directory. Adds the same storage configuration conditional block used by the server and importer templates, supporting both S3 and filesystem strategies.

Implements TC-5445

Assisted-by: Claude Code